### PR TITLE
Develop

### DIFF
--- a/src/Ladder.cpp
+++ b/src/Ladder.cpp
@@ -87,7 +87,7 @@ IsLadderCaptured( const int depth, search_game_info_t *game, const int ren_xy, c
   int escape_color, capture_color, escape_xy, capture_xy, neighbor;
   bool result;
   
-  if (depth >= 100) {
+  if (depth >= 100 || game->moves >= MAX_RECORDS - 1) {
     return ALIVE;
   }
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -16,7 +16,8 @@ using namespace std;
 void
 Simulation( game_info_t *game, int starting_color, std::mt19937_64 *mt )
 {
-  int color = starting_color, pos = -1, pass_count = (game->record[game->moves - 1].pos == PASS && game->moves > 1);
+  int color = starting_color, pos = -1;
+  int pass_count = 0;
 
   // シミュレーション打ち切り手数を設定
   int length = MAX_MOVES - game->moves;

--- a/src/UctSearch.cpp
+++ b/src/UctSearch.cpp
@@ -1565,16 +1565,19 @@ UctAnalyze( game_info_t *game, int color )
   for (int y = board_start; y <= board_end; y++) {
     for (int x = board_start; x <= board_end; x++) {
       const int pos = POS(x, y);
-      const double ownership_value = (double)statistic[pos].colors[S_BLACK] / uct_node[current_root].move_count;
-      if (ownership_value > 0.5) {
-	black++;
-      } else {
-	white++;
+      const double black_ownership = (double)statistic[pos].colors[S_BLACK] / uct_node[current_root].move_count;
+      const double white_ownership = (double)statistic[pos].colors[S_WHITE] / uct_node[current_root].move_count;
+      if (black_ownership > 0.5) {
+        black++;
+      }
+      if (white_ownership > 0.5) {
+        white++;
       }
     }
   }
 
-  PrintOwner(&uct_node[current_root], color, owner);
+  PrintOwner(&uct_node[current_root], S_BLACK, owner);
+  PrintOwner(&uct_node[current_root], S_WHITE, owner);
 
   return black - white;
 }


### PR DESCRIPTION
- Fix buffer overflow in `IsLadderCaptured()` at very long game.
- Don't include pass in tree search as end of game in `Simulation()`. Pass win rate was wrong, when there are only suicide move.
- Dame beside seki were counted as white's territory.
