### PR TITLE
Fix misc

### DIFF
--- a/src/Gtp.cpp
+++ b/src/Gtp.cpp
@@ -28,6 +28,7 @@ using namespace std;
 //  コマンドの処理用のバッファ
 char input[BUF_SIZE], input_copy[BUF_SIZE];
 char *next_token;
+int command_id;
 
 //  応答用の文字列
 char brank[] = "";
@@ -135,9 +136,20 @@ GTP_main( void )
   while (fgets(input, sizeof(input), stdin) != NULL) {
     char *command;
     bool nocommand = true;
+    command_id = -1;
 
-    STRCPY(input_copy, BUF_SIZE, input);
-    command = STRTOK(input, DELIM, &next_token);
+    if (isdigit(input[0])) {
+      char buf[BUF_SIZE];
+      STRCPY(buf, BUF_SIZE, input);
+      char *strid = STRTOK(buf, DELIM, &next_token);
+      command_id = atoi(strid);
+      command = STRTOK(nullptr, DELIM, &next_token);
+      int offset = command - buf;
+      STRCPY(input_copy, BUF_SIZE, input + offset);
+    } else {
+      STRCPY(input_copy, BUF_SIZE, input);
+      command = STRTOK(input, DELIM, &next_token);
+    }
     CHOMP(command);
 
     for (const GTP_command_t& cmd : gtpcmd) {
@@ -165,7 +177,10 @@ static void
 GTP_response( const char *res, bool success )
 {
   if (success){
-    cout << "= " << res << endl << endl;
+    if (command_id >= 0)
+      cout << "=" << command_id << " " << res << endl << endl;
+    else
+      cout << "= " << res << endl << endl;
   } else {
     if (res != NULL) {
       cerr << res << endl;

--- a/src/Gtp.cpp
+++ b/src/Gtp.cpp
@@ -826,6 +826,7 @@ GTP_loadsgf( void )
   InitializeBoard(game);
   InitializeSearchSetting();
   InitializeUctHash();
+  SetKomi(sgf.komi);
 
   // あらかじめ置いてある石を配置
   for (int i = 0; i < sgf.handicap_stones; i++) {

--- a/src/UctSearch.cpp
+++ b/src/UctSearch.cpp
@@ -430,7 +430,9 @@ UctSearchGenmove( game_info_t *game, int color )
 
   // 探索情報をクリア
   if (!pondered) {
-    memset(statistic, 0, sizeof(statistic_t) * board_max);
+    for (int i = 0; i < board_max; i++) {
+      statistic[i].clear();
+    }
     fill_n(criticality_index, board_max, 0);
     for (int i = 0; i < board_max; i++) {
       criticality[i] = 0.0;
@@ -574,7 +576,9 @@ UctSearchPondering( game_info_t *game, int color )
   }
 
   // 探索情報をクリア
-  memset(statistic, 0, sizeof(statistic_t) * board_max);  
+  for (int i = 0; i < board_max; i++) {
+    statistic[i].clear();
+  }
   fill_n(criticality_index, board_max, 0);  
   for (int i = 0; i < board_max; i++) {
     criticality[i] = 0.0;    
@@ -1498,7 +1502,9 @@ UctAnalyze( game_info_t *game, int color )
   thread *handle[THREAD_MAX];
 
   // 探索情報をクリア
-  memset(statistic, 0, sizeof(statistic_t) * board_max);  
+  for (int i = 0; i < board_max; i++) {
+    statistic[i].clear();
+  }
   fill_n(criticality_index, board_max, 0);  
   for (int i = 0; i < board_max; i++) {
     criticality[i] = 0.0;
@@ -1571,7 +1577,9 @@ CopyCriticality( double *dest )
 void
 CopyStatistic( statistic_t *dest )
 {
-  memcpy(dest, statistic, sizeof(statistic_t)* BOARD_MAX); 
+  for (int i = 0; i < board_max; i++) {
+    dest[i] = statistic[i];
+  }
 }
 
 
@@ -1586,7 +1594,9 @@ UctSearchGenmoveCleanUp( game_info_t *game, int color )
   child_node_t *uct_child;
   thread *handle[THREAD_MAX];
 
-  memset(statistic, 0, sizeof(statistic_t)* board_max); 
+  for (int i = 0; i < board_max; i++) {
+    statistic[i].clear();
+  }
   fill_n(criticality_index, board_max, 0); 
   for (int i = 0; i < board_max; i++) {
     criticality[i] = 0.0;

--- a/src/UctSearch.h
+++ b/src/UctSearch.h
@@ -80,6 +80,19 @@ struct thread_arg_t {
 
 struct statistic_t {
   std::atomic<int> colors[3];  // その箇所を領地にした回数
+
+  void clear() {
+    for (int i = 0; i < 3; i++) {
+      colors[i] = 0;
+    }
+  }
+
+  statistic_t& operator=(const statistic_t& v) {
+    for (int i = 0; i < 3; i++) {
+      colors[i] = v.colors[i].load();
+    }
+    return *this;
+  }
 };
 
 struct child_node_t {


### PR DESCRIPTION
いくつか気になった点を変更しました。
- statistic_tへのmemsetでの警告修正
- GTPにIDがついている場合の対応
- SGFのコミの反映
- SGFのABタグが長く改行が入っている場合の対応

背景としてAya・Fuego・KataGoを参考に日本ルール対応の実験をしています。  https://github.com/kobanium/Ray/compare/master...zakki:exp-japanese-rule?expand=1
Fuegoのリグレッションテストで日本ルールのscoring_static.tst, scoring_final.tst, cleanup_japanese_rules.tstをとりあえず目標にしています。
現状は不完全ではありますがそれなりには日本ルールっぽくパスするようになりました。
目数に大差があるときの挙動や、KataGoで言うところののコウやセキ対応が未実装で、プレイアウト数を増やしてもいくつか間違います。
https://sourceforge.net/p/fuego/code/HEAD/tree/trunk/regression/
今は日本ルール対応のインターフェースはFuego固有のGTP拡張経由で、それでいいのか検討が必要そうです。