### PR TITLE
Fix some potential bugs for lz-analyze.

### DIFF
--- a/src/common/Message.cpp
+++ b/src/common/Message.cpp
@@ -429,7 +429,6 @@ PrintLeelaZeroAnalyze( const uct_node_t *root )
   struct verbose_t {
     std::string lz_pos;
     int visits, winrate, prior, lcb, index;
-    const char *pv;
   };
 
   std::vector<verbose_t> child_verbose;
@@ -444,12 +443,12 @@ PrintLeelaZeroAnalyze( const uct_node_t *root )
     v.lz_pos = std::string{cpos};
     v.visits = c->move_count.load(std::memory_order_relaxed);
 
-    double raw_winrate = 0.5f;
+    double winrate = 0.5f;
     if (v.visits > 0) {
-        raw_winrate = (double)(c->win.load(std::memory_order_relaxed)) / v.visits;
+      winrate = (double)(c->win.load(std::memory_order_relaxed)) / v.visits;
     }
 
-    v.winrate = std::min(10000, (int)(10000 * raw_winrate));
+    v.winrate = std::min(10000, (int)(10000 * winrate));
     v.prior = std::min(10000, (int)(10000 * c->rate));
     v.lcb = v.winrate;
     v.index = c->index;


### PR DESCRIPTION
There is some potential bug in the ```lz-analyze``` and  ```lz-analyze_genmove``` if we give the unexpected tags to it.

For example,

```
in: lz-analyze minmoves 25
```

It is a legal analysis command. But it is unacceptable for previous version Ray.